### PR TITLE
fix examples link, narrow javadoc aggregation modules

### DIFF
--- a/scripts/gen-protonj2-release-docs
+++ b/scripts/gen-protonj2-release-docs
@@ -23,11 +23,12 @@ from generate import *
 def gen_protonj2_api(release, source_dir, release_dir):
     toplevel_pom = join(source_dir, "pom.xml")
     generated_docs = join(source_dir, "target/site/apidocs")
+    modules = ".,protonj2,protonj2-client,protonj2-test-driver"
     output_dir = join(release_dir, "api")
 
     remove(output_dir)
 
-    call("mvn -f {} clean javadoc:aggregate", toplevel_pom)
+    call("mvn -f {} clean javadoc:aggregate -pl '{}'", toplevel_pom, modules)
 
     copy(generated_docs, output_dir)
 

--- a/scripts/gen-protonj2-release-page
+++ b/scripts/gen-protonj2-release-page
@@ -32,7 +32,7 @@ documentation = \
 <div class="two-column" markdown="1">
 
  - [API reference](api/index.html)
- - [Examples](https://github.com/apache/qpid-protonj2/tree/{source_release}/examples)
+ - [Client Examples](https://github.com/apache/qpid-protonj2/tree/{source_release}/protonj2-client-examples)
 
 </div>
 """


### PR DESCRIPTION
Fixes a broken example link and renames it for clarify.

Stops including examples and JMH generated class stuff in javadocs. (Perhaps debatable whether the test driver should be included or not, might be nicer for other more typical usages to omit it too)